### PR TITLE
Create B827EBFFFE2A809E.json

### DIFF
--- a/B827EBFFFE2A809E.json
+++ b/B827EBFFFE2A809E.json
@@ -1,0 +1,18 @@
+{
+  "gateway_conf": {
+    "gateway_ID": "B827EBFFFE2A809E",
+    "servers": [
+      {
+        "server_address": "router.eu.thethings.network",
+        "serv_port_up": 1700,
+        "serv_port_down": 1700,
+        "serv_enabled": true
+      }
+    ],
+    "ref_latitude": 51.652,
+    "ref_longitude": -0.08,
+    "ref_altitude": 40,
+    "contact_email": "lorawan.enfield@gmail.com",
+    "description": "Enfield, UK"
+  }
+}


### PR DESCRIPTION
{
  "gateway_conf": {
    "gateway_ID": "B827EBFFFE2A809E",
    "servers": [
      {
        "server_address": "router.eu.thethings.network",
        "serv_port_up": 1700,
        "serv_port_down": 1700,
        "serv_enabled": true
      }
    ],
    "ref_latitude": 51.652,
    "ref_longitude": -0.08,
    "ref_altitude": 40,
    "contact_email": "lorawan.enfield@gmail.com",
    "description": "Enfield, UK"
  }
}