### PR TITLE
Add another GW for St. Gallen

### DIFF
--- a/B827EBFFFE148FEC.json
+++ b/B827EBFFFE148FEC.json
@@ -6,6 +6,6 @@
 		"ref_longitude": 9.43515104,
 		"ref_altitude": 560,
 		"contact_email": "ttn@zone11.ch",
-		"description": "zone11-gw-01" 
+		"description": "gw-01-9402-horchental" 
 	}
 }

--- a/B827EBFFFE7D5356.json
+++ b/B827EBFFFE7D5356.json
@@ -6,6 +6,6 @@
                 "ref_longitude": 9.45953740,
                 "ref_altitude": 903,
                 "contact_email": "ttn@zone11.ch",
-                "description": "gw-02-9043-Kanti" 
+                "description": "gw-02-9043-kanti" 
         }
 }

--- a/B827EBFFFE7D5356.json
+++ b/B827EBFFFE7D5356.json
@@ -1,0 +1,11 @@
+{
+        "gateway_conf": {
+                "gateway_ID": "B827EBFFFE7D5356",
+                "servers": [ { "server_address": "ttn.opennetworkinfrastructure.org", "serv_port_up": 1700, "serv_port_down": 1700, "serv_enabled": true } ],
+                "ref_latitude": 47.40810734,
+                "ref_longitude": 9.45953740,
+                "ref_altitude": 903,
+                "contact_email": "ttn@zone11.ch",
+                "description": "gw-02-9043-Kanti" 
+        }
+}


### PR DESCRIPTION
Another GW for St. Gallen, located in Trogen
Cleanup hostnames