### PR TITLE
Create B827EBFFFE1135CA.json

### DIFF
--- a/B827EBFFFE1135CA.json
+++ b/B827EBFFFE1135CA.json
@@ -1,0 +1,17 @@
+{
+	"gateway_conf": {
+	 	"gateway_ID": "B827EBFFFE1135CA",
+		"servers": [ 
+			{ "server_address": "asia-se.thethings.network",
+				"serv_port_up": 1700,
+				"serv_port_down": 1700,
+				"serv_enabled": true 
+			}
+			],
+			"ref_latitude": 13.86863564,
+			"ref_longitude": 100.56750174,
+			"ref_altitude": 580,
+			"contact_email": "montri.k@innetweb.com",
+			"description": "Gs LoRaWAN Gateway Brunch in Infinite" 
+	}
+}


### PR DESCRIPTION
{
	"gateway_conf": {
	 	"gateway_ID": "B827EBFFFE1135CA",
		"servers": [ 
			{ "server_address": "asia-se.thethings.network",
				"serv_port_up": 1700,
				"serv_port_down": 1700,
				"serv_enabled": true 
			}
			],
			"ref_latitude": 13.86863564,
			"ref_longitude": 100.56750174,
			"ref_altitude": 580,
			"contact_email": "montri.k@innetweb.com",
			"description": "Gs LoRaWAN Gateway Brunch in Infinite" 
	}
}
