### PR TITLE
Committing dlfr-dekrom gateway config

### DIFF
--- a/B827EBFFFED8DC0B.json
+++ b/B827EBFFFED8DC0B.json
@@ -1,0 +1,16 @@
+{
+    "gateway_conf": {
+        "gateway_ID": "B827EBFFFED8DC0B",
+        "servers": [{
+            "server_address": "router.eu.thethings.network",
+            "serv_port_up": 1700,
+            "serv_port_down": 1700,
+            "serv_enabled": true
+        }],
+        "ref_latitude": 52.20985731,
+        "ref_longitude": 4.42922042,
+        "ref_altitude": 2,
+        "contact_email": "d.dulfer@outlook.com",
+        "description": "De Krom, Katwijk (The Netherlands)"
+    }
+}


### PR DESCRIPTION
Gateway configuration for RAK833 based gateway De Krom, Katwijk (The Netherlands)