### PR TITLE
B827EBFFFEAC264A.json

### DIFF
--- a/B827EBFFFEAC264A.json
+++ b/B827EBFFFEAC264A.json
@@ -1,0 +1,18 @@
+{
+  "gateway_conf": {
+    "gateway_ID": "B827EBFFFEAC264A",
+    "servers": [
+      {
+        "server_address": "router.eu.thethings.network",
+        "serv_port_up": 1700,
+        "serv_port_down": 1700,
+        "serv_enabled": true
+      }
+    ],
+    "ref_latitude": 52.08511225,
+    "ref_longitude": 4.30051452,
+    "ref_altitude": 40,
+    "contact_email": "gratziano@gmail.com",
+    "description": "YG ic880a rpi based TEST Gateway"
+  }
+}


### PR DESCRIPTION
{
  "gateway_conf": {
    "gateway_ID": "B827EBFFFEAC264A",
    "servers": [
      {
        "server_address": "router.eu.thethings.network",
        "serv_port_up": 1700,
        "serv_port_down": 1700,
        "serv_enabled": true
      }
    ],
    "ref_latitude": 52.08511225,
    "ref_longitude": 4.30051452,
    "ref_altitude": 40,
    "contact_email": "gratziano@gmail.com",
    "description": "YG ic880a rpi based TEST Gateway"
  }
}