### PR TITLE
Update B827EBFFFEDC6BD5.json

### DIFF
--- a/B827EBFFFEDC6BD5.json
+++ b/B827EBFFFEDC6BD5.json
@@ -3,7 +3,7 @@
     "gateway_ID": "B827EBFFFEDC6BD5",
     "servers": [
       {
-        "server_address": "192.168.0.99",
+        "server_address": "router.eu.thethings.network",
         "serv_port_up": 1700,
         "serv_port_down": 1700,
         "serv_enabled": true


### PR DESCRIPTION
Mistake in the config file.

I used the IP that I used to SSH into my raspberry pi for the server_address, rather than "router.eu.thethings.network".

I believe this was the cause of the "failed to start the concentrator" error that I observed in the raspberry pi system logs.